### PR TITLE
feat: extract PDF text on CV feedback uploads

### DIFF
--- a/plugin_cv_feedback
+++ b/plugin_cv_feedback
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Kovacic CV Feedback (ES) + reCAPTCHA v3
 Description: Envío de CV con feedback por IA (PDF/DOCX). Si el PDF no es legible en el servidor, el navegador extrae el texto con PDF.js y, si es escaneado, hace OCR con Tesseract.js; luego envía el texto oculto y el servidor genera un DOCX temporal desde ese texto (flujo fiable).
-Version: 1.6.0
+Version: 1.6.1
 Author: Tim Kuijten - Kovacic Executive Talent Research
 */
 
@@ -245,7 +245,7 @@ document.addEventListener('DOMContentLoaded', function(){
       for (let p=1; p<=pdf.numPages; p++){
         const page = await pdf.getPage(p);
         const content = await page.getTextContent();
-        const strings = content.items.map(it => it.str);
+        const strings = content.items.map(it=>it.str);
         full += strings.join(' ') + '\\n\\n';
       }
       return full.trim();
@@ -256,11 +256,8 @@ document.addEventListener('DOMContentLoaded', function(){
     if (!window.Tesseract || !window.pdfjsLib) return '';
     const buf = await file.arrayBuffer();
     const pdf = await window.pdfjsLib.getDocument({ data: buf }).promise;
-
-    // offscreen canvas
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
-
     let ocrText = '';
     for (let p=1; p<=pdf.numPages; p++){
       const page = await pdf.getPage(p);
@@ -268,59 +265,57 @@ document.addEventListener('DOMContentLoaded', function(){
       canvas.width = viewport.width;
       canvas.height = viewport.height;
       await page.render({ canvasContext: ctx, viewport }).promise;
-
       const dataURL = canvas.toDataURL('image/png');
       try {
-        const { data: { text } } = await Tesseract.recognize(
-          dataURL,
-          'spa+eng',
-          { logger: ()=>{} }
-        );
+        const { data:{ text } } = await Tesseract.recognize(dataURL, 'spa+eng', { logger: ()=>{} });
         if (text) ocrText += text + '\\n\\n';
-      } catch(e) {
-        // continuar aunque una página falle
-      }
+      } catch(e){}
       ctx.clearRect(0,0,canvas.width,canvas.height);
     }
     return ocrText.trim();
   }
 
+  async function extractPdfText(file){
+    let txt = await extractPdfWithPDFjs(file);
+    if (!txt) txt = await ocrPdfWithTesseract(file);
+    return txt;
+  }
+
+  if (fileInput){
+    fileInput.addEventListener('change', async function(){
+      cvTextField.value = '';
+      var f = fileInput.files && fileInput.files[0];
+      if (!f) return;
+      var isPdf = (f.type === 'application/pdf') || (/\.pdf$/i.test(f.name));
+      if (isPdf) {
+        cvTextField.value = await extractPdfText(f);
+      }
+    });
+  }
+
   form.addEventListener('submit', function(e){
     if (submitting) return;
+    e.preventDefault();
     var file = fileInput && fileInput.files && fileInput.files[0] ? fileInput.files[0] : null;
-    if (!file) return;
-
-    var isPdf = (file.type === 'application/pdf') || (/\.pdf$/i.test(file.name));
-    if (isPdf) {
-      e.preventDefault();
-      (async function(){
-        // 1) Intento PDF.js
-        if (!cvTextField.value) {
-          const pdfText = await extractPdfWithPDFjs(file);
-          if (pdfText && pdfText.length > 0) cvTextField.value = pdfText;
-        }
-        // 2) OCR si sigue vacío (escaneado)
-        if (!cvTextField.value) {
-          const ocrText = await ocrPdfWithTesseract(file);
-          if (ocrText && ocrText.length > 0) cvTextField.value = ocrText;
-        }
-
-        // Continuar (con reCAPTCHA si está)
-        var tokenField = form.querySelector('input[name="kcvf_recaptcha_token"]');
-        if (window.grecaptcha && typeof grecaptcha.execute === 'function') {
-          grecaptcha.ready(function(){
-            grecaptcha.execute('%SITE_KEY%', {action: 'cv_submit'}).then(function(token){
-              if (tokenField) tokenField.value = token;
-              submitting = true;
-              form.submit();
-            });
+    var isPdf = file && ((file.type === 'application/pdf') || (/\.pdf$/i.test(file.name)));
+    (async function(){
+      if (isPdf && !cvTextField.value) {
+        cvTextField.value = await extractPdfText(file);
+      }
+      var tokenField = form.querySelector('input[name="kcvf_recaptcha_token"]');
+      if (window.grecaptcha && typeof grecaptcha.execute === 'function') {
+        grecaptcha.ready(function(){
+          grecaptcha.execute('%SITE_KEY%', {action:'cv_submit'}).then(function(token){
+            if (tokenField) tokenField.value = token;
+            submitting = true;
+            form.submit();
           });
-        } else {
-          submitting = true;
-          form.submit();
-        }
-      })();
-    }
+        });
+      } else {
+        submitting = true;
+        form.submit();
+      }
+    })();
   });
 });
 JS;


### PR DESCRIPTION
## Summary
- ensure CV feedback form extracts text from PDFs with pdf.js and Tesseract
- always send extracted text in `cv_text` and run reCAPTCHA before submitting

## Testing
- `php -l plugin_cv_feedback`


------
https://chatgpt.com/codex/tasks/task_e_68b21c4dc968832ab352680ce0900914