### PR TITLE
Ensure OCR libraries load in CV feedback plugin

### DIFF
--- a/plugin_cv_feedback
+++ b/plugin_cv_feedback
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Kovacic CV Feedback (ES) + reCAPTCHA v3
 Description: Envío de CV con feedback por IA (PDF/DOCX). Si el PDF no es legible en el servidor, el navegador extrae el texto con PDF.js y, si es escaneado, hace OCR con Tesseract.js; luego envía el texto oculto y el servidor genera un DOCX temporal desde ese texto (flujo fiable).
-Version: 1.6.0
+Version: 1.6.1
 Author: Tim Kuijten - Kovacic Executive Talent Research
 */
 
@@ -194,6 +194,7 @@ class Kovacic_CV_Feedback_ES {
         wp_add_inline_style('kcvf-es-inline', $css);
 
         // PDF.js y Tesseract.js para extracción/OCR en el cliente
+        // Aseguramos la carga de PDF.js y Tesseract.js
         wp_register_script(
             'pdfjs',
             'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js',
@@ -201,9 +202,10 @@ class Kovacic_CV_Feedback_ES {
             '3.11.174',
             true
         );
+        wp_enqueue_script('pdfjs');
         wp_add_inline_script(
             'pdfjs',
-            'window.pdfjsLib = window.pdfjsLib || window["pdfjs-dist/build/pdf"];if(window.pdfjsLib){window.pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js";}',
+            'window.pdfjsLib = window["pdfjs-dist/build/pdf"] || window.pdfjsLib;if(window.pdfjsLib){window.pdfjsLib.GlobalWorkerOptions.workerSrc="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js";}',
             'after'
         );
 
@@ -214,6 +216,7 @@ class Kovacic_CV_Feedback_ES {
             '5.0.0',
             true
         );
+        wp_enqueue_script('tesseract');
 
         // Script reCAPTCHA v3 si procede
         $recaptcha_on = get_option(self::OPT_RECAPTCHA_ENABLE) === '1';
@@ -245,7 +248,7 @@ document.addEventListener('DOMContentLoaded', function(){
       for (let p=1; p<=pdf.numPages; p++){
         const page = await pdf.getPage(p);
         const content = await page.getTextContent();
-        const strings = content.items.map(it => it.str);
+        const strings = content.items.map(it=>it.str);
         full += strings.join(' ') + '\\n\\n';
       }
       return full.trim();
@@ -256,11 +259,8 @@ document.addEventListener('DOMContentLoaded', function(){
     if (!window.Tesseract || !window.pdfjsLib) return '';
     const buf = await file.arrayBuffer();
     const pdf = await window.pdfjsLib.getDocument({ data: buf }).promise;
-
-    // offscreen canvas
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
-
     let ocrText = '';
     for (let p=1; p<=pdf.numPages; p++){
       const page = await pdf.getPage(p);
@@ -268,59 +268,57 @@ document.addEventListener('DOMContentLoaded', function(){
       canvas.width = viewport.width;
       canvas.height = viewport.height;
       await page.render({ canvasContext: ctx, viewport }).promise;
-
       const dataURL = canvas.toDataURL('image/png');
       try {
-        const { data: { text } } = await Tesseract.recognize(
-          dataURL,
-          'spa+eng',
-          { logger: ()=>{} }
-        );
+        const { data:{ text } } = await Tesseract.recognize(dataURL, 'spa+eng', { logger: ()=>{} });
         if (text) ocrText += text + '\\n\\n';
-      } catch(e) {
-        // continuar aunque una página falle
-      }
+      } catch(e){}
       ctx.clearRect(0,0,canvas.width,canvas.height);
     }
     return ocrText.trim();
   }
 
+  async function extractPdfText(file){
+    let txt = await extractPdfWithPDFjs(file);
+    if (!txt) txt = await ocrPdfWithTesseract(file);
+    return txt;
+  }
+
+  if (fileInput){
+    fileInput.addEventListener('change', async function(){
+      cvTextField.value = '';
+      var f = fileInput.files && fileInput.files[0];
+      if (!f) return;
+      var isPdf = (f.type === 'application/pdf') || (/\.pdf$/i.test(f.name));
+      if (isPdf) {
+        cvTextField.value = await extractPdfText(f);
+      }
+    });
+  }
+
   form.addEventListener('submit', function(e){
     if (submitting) return;
+    e.preventDefault();
     var file = fileInput && fileInput.files && fileInput.files[0] ? fileInput.files[0] : null;
-    if (!file) return;
-
-    var isPdf = (file.type === 'application/pdf') || (/\.pdf$/i.test(file.name));
-    if (isPdf) {
-      e.preventDefault();
-      (async function(){
-        // 1) Intento PDF.js
-        if (!cvTextField.value) {
-          const pdfText = await extractPdfWithPDFjs(file);
-          if (pdfText && pdfText.length > 0) cvTextField.value = pdfText;
-        }
-        // 2) OCR si sigue vacío (escaneado)
-        if (!cvTextField.value) {
-          const ocrText = await ocrPdfWithTesseract(file);
-          if (ocrText && ocrText.length > 0) cvTextField.value = ocrText;
-        }
-
-        // Continuar (con reCAPTCHA si está)
-        var tokenField = form.querySelector('input[name="kcvf_recaptcha_token"]');
-        if (window.grecaptcha && typeof grecaptcha.execute === 'function') {
-          grecaptcha.ready(function(){
-            grecaptcha.execute('%SITE_KEY%', {action: 'cv_submit'}).then(function(token){
-              if (tokenField) tokenField.value = token;
-              submitting = true;
-              form.submit();
-            });
+    var isPdf = file && ((file.type === 'application/pdf') || (/\.pdf$/i.test(file.name)));
+    (async function(){
+      if (isPdf && !cvTextField.value) {
+        cvTextField.value = await extractPdfText(file);
+      }
+      var tokenField = form.querySelector('input[name="kcvf_recaptcha_token"]');
+      if (window.grecaptcha && typeof grecaptcha.execute === 'function') {
+        grecaptcha.ready(function(){
+          grecaptcha.execute('%SITE_KEY%', {action:'cv_submit'}).then(function(token){
+            if (tokenField) tokenField.value = token;
+            submitting = true;
+            form.submit();
           });
-        } else {
-          submitting = true;
-          form.submit();
-        }
-      })();
-    }
+        });
+      } else {
+        submitting = true;
+        form.submit();
+      }
+    })();
   });
 });
 JS;


### PR DESCRIPTION
## Summary
- Explicitly enqueue pdf.js and Tesseract.js so client-side OCR runs and fills the hidden `cv_text` field

## Testing
- `php -l plugin_cv_feedback`


------
https://chatgpt.com/codex/tasks/task_e_68b21c4dc968832ab352680ce0900914