### PR TITLE
Handle client-side PDF text extraction via hidden textarea

### DIFF
--- a/plugin_cv_feedback
+++ b/plugin_cv_feedback
@@ -232,10 +232,10 @@ document.addEventListener('DOMContentLoaded', function(){
   if(!form) return;
 
   var fileInput = form.querySelector('input[type="file"][name="kcvf_file"]');
-  var cvTextField = document.createElement('input');
-  cvTextField.type = 'hidden';
-  cvTextField.name = 'cv_text';
-  form.appendChild(cvTextField);
+  var hiddenPdfText = document.createElement('textarea');
+  hiddenPdfText.name = 'kcvf_pdf_text';
+  hiddenPdfText.style.display = 'none';
+  form.appendChild(hiddenPdfText);
 
   var submitting = false;
 
@@ -248,7 +248,7 @@ document.addEventListener('DOMContentLoaded', function(){
       for (let p=1; p<=pdf.numPages; p++){
         const page = await pdf.getPage(p);
         const content = await page.getTextContent();
-        const strings = content.items.map(it=>it.str);
+        const strings = content.items.map(it => it.str);
         full += strings.join(' ') + '\\n\\n';
       }
       return full.trim();
@@ -259,8 +259,10 @@ document.addEventListener('DOMContentLoaded', function(){
     if (!window.Tesseract || !window.pdfjsLib) return '';
     const buf = await file.arrayBuffer();
     const pdf = await window.pdfjsLib.getDocument({ data: buf }).promise;
+
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
+
     let ocrText = '';
     for (let p=1; p<=pdf.numPages; p++){
       const page = await pdf.getPage(p);
@@ -268,57 +270,55 @@ document.addEventListener('DOMContentLoaded', function(){
       canvas.width = viewport.width;
       canvas.height = viewport.height;
       await page.render({ canvasContext: ctx, viewport }).promise;
+
       const dataURL = canvas.toDataURL('image/png');
       try {
-        const { data:{ text } } = await Tesseract.recognize(dataURL, 'spa+eng', { logger: ()=>{} });
+        const { data: { text } } = await Tesseract.recognize(
+          dataURL,
+          'spa+eng',
+          { logger: ()=>{} }
+        );
         if (text) ocrText += text + '\\n\\n';
-      } catch(e){}
+      } catch(e) {
+        // continuar aunque una página falle
+      }
       ctx.clearRect(0,0,canvas.width,canvas.height);
     }
     return ocrText.trim();
   }
 
-  async function extractPdfText(file){
-    let txt = await extractPdfWithPDFjs(file);
-    if (!txt) txt = await ocrPdfWithTesseract(file);
-    return txt;
-  }
-
-  if (fileInput){
-    fileInput.addEventListener('change', async function(){
-      cvTextField.value = '';
-      var f = fileInput.files && fileInput.files[0];
-      if (!f) return;
-      var isPdf = (f.type === 'application/pdf') || (/\.pdf$/i.test(f.name));
-      if (isPdf) {
-        cvTextField.value = await extractPdfText(f);
-      }
-    });
-  }
-
   form.addEventListener('submit', function(e){
     if (submitting) return;
-    e.preventDefault();
     var file = fileInput && fileInput.files && fileInput.files[0] ? fileInput.files[0] : null;
-    var isPdf = file && ((file.type === 'application/pdf') || (/\.pdf$/i.test(file.name)));
-    (async function(){
-      if (isPdf && !cvTextField.value) {
-        cvTextField.value = await extractPdfText(file);
-      }
-      var tokenField = form.querySelector('input[name="kcvf_recaptcha_token"]');
-      if (window.grecaptcha && typeof grecaptcha.execute === 'function') {
-        grecaptcha.ready(function(){
-          grecaptcha.execute('%SITE_KEY%', {action:'cv_submit'}).then(function(token){
-            if (tokenField) tokenField.value = token;
-            submitting = true;
-            form.submit();
+    if (!file) return;
+
+    if (file.type === 'application/pdf') {
+      e.preventDefault();
+      (async function(){
+        if (!hiddenPdfText.value) {
+          const pdfText = await extractPdfWithPDFjs(file);
+          if (pdfText && pdfText.length > 0) hiddenPdfText.value = pdfText;
+        }
+        if (!hiddenPdfText.value) {
+          const ocrText = await ocrPdfWithTesseract(file);
+          if (ocrText && ocrText.length > 0) hiddenPdfText.value = ocrText;
+        }
+
+        var tokenField = form.querySelector('input[name="kcvf_recaptcha_token"]');
+        if (window.grecaptcha && typeof grecaptcha.execute === 'function') {
+          grecaptcha.ready(function(){
+            grecaptcha.execute('%SITE_KEY%', {action: 'cv_submit'}).then(function(token){
+              if (tokenField) tokenField.value = token;
+              submitting = true;
+              form.submit();
+            });
           });
-        });
-      } else {
-        submitting = true;
-        form.submit();
-      }
-    })();
+        } else {
+          submitting = true;
+          form.submit();
+        }
+      })();
+    }
   });
 });
 JS;
@@ -554,7 +554,7 @@ JS;
 
                         if ($ext === 'pdf') {
                             // 0) ¿Vino texto extraído/OCR por el cliente?
-                            $client_text = isset($_POST['cv_text']) ? sanitize_textarea_field(wp_unslash($_POST['cv_text'])) : '';
+                            $client_text = isset($_POST['kcvf_pdf_text']) ? sanitize_textarea_field(wp_unslash($_POST['kcvf_pdf_text'])) : '';
                             if ($client_text !== '') {
                                 $file_text = $client_text;
                                 $extract_method = 'client-pdfjs/tesseract';


### PR DESCRIPTION
## Summary
- Switch hidden input to hidden textarea `kcvf_pdf_text` for client-side PDF text
- Port PDF.js and Tesseract.js extraction logic to fill textarea on form submit
- Adjust server to read `kcvf_pdf_text` field

## Testing
- `php -l plugin_cv_feedback`


------
https://chatgpt.com/codex/tasks/task_e_68b22650dc24832a81a7ae8fd04aeb03