### PR TITLE
Add frontend shortcode and public AJAX handlers

### DIFF
--- a/bulkemail-shortcode.md
+++ b/bulkemail-shortcode.md
@@ -1,0 +1,9 @@
+# Correo Masivo Shortcode
+
+Place the shortcode `[kt_bulk_mailer]` on a page or template to display the Correo Masivo form on the front end. Scripts and styles are enqueued automatically when the shortcode is present. Only users with the `manage_options` capability can view and use the form.
+
+Example in a template:
+
+```php
+echo do_shortcode('[kt_bulk_mailer]');
+```


### PR DESCRIPTION
## Summary
- expose Correo Masivo via `[kt_bulk_mailer]` shortcode with proper asset loading
- allow unauthenticated AJAX requests while preserving nonce and capability checks
- document usage of `[kt_bulk_mailer]` shortcode

## Testing
- `php -l bulkemail.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2633009bc832ab09c40aeb1d9f59a