### PR TITLE
Allow public client board links

### DIFF
--- a/templates/kvt-board.php
+++ b/templates/kvt-board.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Template for displaying Kovacic pipeline board via shared link.
+ */
+get_header();
+
+echo do_shortcode('[kovacic_pipeline]');
+
+get_footer();


### PR DESCRIPTION
## Summary
- Allow `[kovacic_pipeline]` to render for valid `kvt_board` slugs without login
- Render shared client boards via new `kvt-board` template on `template_redirect`
- Load frontend assets when visiting a shared board

## Testing
- `php -l plugin_pipeline.php`
- `php -l templates/kvt-board.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3791cb2c4832aaf72facb86d0400d