### PR TITLE
Add client board viewer and update share link redirect

### DIFF
--- a/plugin_client_board_viewer.php
+++ b/plugin_client_board_viewer.php
@@ -1,0 +1,67 @@
+<?php
+/*
+Plugin Name: Kovacic Client Board Viewer
+Description: Public viewer for Kovacic pipeline boards.
+Version: 1.0.0
+Author: Tim Kuijten - Kovacic Executive Talent Research
+*/
+
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Shortcode handler for [kvt_public_board].
+ * Validates the requested board slug and reuses the main pipeline shortcode
+ * to render the Kanban board for public viewers.
+ */
+function kvt_public_board_shortcode($atts = []) {
+    $slug  = isset($_GET['kvt_board']) ? sanitize_text_field(wp_unslash($_GET['kvt_board'])) : '';
+    $links = get_option('kvt_client_links', []);
+    if (!$slug || !isset($links[$slug])) {
+        return '<div class="kvt-wrapper"><p>Tablero no disponible.</p></div>';
+    }
+    return do_shortcode('[kovacic_pipeline]');
+}
+add_shortcode('kvt_public_board', 'kvt_public_board_shortcode');
+
+/**
+ * Ensure the same CSS/JS assets used by the pipeline plugin are loaded.
+ */
+function kvt_public_board_enqueue_assets() {
+    if (wp_style_is('kvt-style', 'registered')) {
+        wp_enqueue_style('kvt-style');
+    }
+    if (wp_script_is('kvt-app', 'registered')) {
+        wp_enqueue_script('kvt-app');
+    }
+}
+add_action('wp_enqueue_scripts', 'kvt_public_board_enqueue_assets');
+
+/**
+ * Register /view-board/ endpoint where the shortcode renders.
+ */
+function kvt_public_board_rewrite() {
+    add_rewrite_rule('^view-board/?$', 'index.php?kvt_public_board=1', 'top');
+}
+add_action('init', 'kvt_public_board_rewrite');
+
+function kvt_public_board_query_vars($vars) {
+    $vars[] = 'kvt_public_board';
+    return $vars;
+}
+add_filter('query_vars', 'kvt_public_board_query_vars');
+
+function kvt_public_board_template_redirect() {
+    if (get_query_var('kvt_public_board')) {
+        status_header(200);
+        nocache_headers();
+        echo '<!DOCTYPE html><html><head>';
+        wp_head();
+        echo '</head><body>';
+        echo do_shortcode('[kvt_public_board]');
+        wp_footer();
+        echo '</body></html>';
+        exit;
+    }
+}
+add_action('template_redirect', 'kvt_public_board_template_redirect');
+

--- a/plugin_pipeline.php
+++ b/plugin_pipeline.php
@@ -1181,7 +1181,7 @@ cv_uploaded|Fecha de subida");
         wp_add_inline_script('kvt-app', 'const KVT_STATUSES='.wp_json_encode($statuses).';', 'before');
         wp_add_inline_script('kvt-app', 'const KVT_COLUMNS='.wp_json_encode($columns).';',  'before');
         wp_add_inline_script('kvt-app', 'const KVT_AJAX="'.esc_js(admin_url('admin-ajax.php')).'";', 'before');
-        wp_add_inline_script('kvt-app', 'const KVT_HOME="'.esc_js(home_url('/base/')).'";', 'before');
+        wp_add_inline_script('kvt-app', 'const KVT_HOME="'.esc_js(home_url('/view-board/')).'";', 'before');
         wp_add_inline_script('kvt-app', 'const KVT_NONCE="'.esc_js(wp_create_nonce('kvt_nonce')).'";', 'before');
         wp_add_inline_script('kvt-app', 'const KVT_CLIENT_VIEW='.($is_client_board?'true':'false').';', 'before');
         wp_add_inline_script('kvt-app', 'const KVT_ALLOWED_FIELDS='.wp_json_encode($fields).';', 'before');
@@ -3201,7 +3201,7 @@ JS;
         if (!preg_match('/^[a-z0-9-]+-[a-z0-9-]+-\d{5}$/i', $slug)) return;
         $links = get_option('kvt_client_links', []);
         if (!isset($links[$slug])) return;
-        $target = home_url('/base/?kvt_board=' . $slug);
+        $target = home_url('/view-board/?kvt_board=' . $slug);
         wp_redirect($target);
         exit;
     }


### PR DESCRIPTION
## Summary
- add public board viewer plugin with shortcode and rewrite endpoint
- redirect shared board links to new viewer page and update pipeline base path

## Testing
- `php -l plugin_client_board_viewer.php`
- `php -l plugin_pipeline.php`


------
https://chatgpt.com/codex/tasks/task_e_68b38abddae4832aaef5a11e2f8a484e