### PR TITLE
feat: new ATS tracker interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Kovacic ATS Tracker
+
+Interface de seguimiento de candidatos con estilo Salesforce.
+
+## Endpoints AJAX
+- `kvt_get_candidates` – lista candidatos (`search`, `client`, `process`, `stage`, `page`).
+- `kvt_update_status` – actualiza etapa del candidato (`id`, `status`).
+- `kvt_add_task` / `kvt_complete_task` / `kvt_delete_task` – gestiona actividad.
+
+## Hooks
+- `admin_post_kvt_export` – exportación CSV/XLS.
+- `kvt_daily_followup` – cron diario para recordatorios.

--- a/css/tracker.css
+++ b/css/tracker.css
@@ -117,6 +117,7 @@
 }
 .kcvf .k-sidehead{font-weight:700;margin-bottom:var(--gap)}
 .kcvf .k-activity{display:grid;gap:10px;max-height:520px;overflow:auto}
+.kcvf .k-activity-toggle{display:none}
 
 /* Pagination */
 .kcvf .k-pager{display:flex;justify-content:space-between;align-items:center;margin-top:calc(var(--gap)*2)}
@@ -133,7 +134,9 @@
 /* Responsive */
 @media (max-width: 960px){
   .kcvf .k-layout{grid-template-columns:1fr}
-  .kcvf .k-sidebar{order:-1}
+  .kcvf .k-activity-toggle{display:block;margin-bottom:calc(var(--gap)*2)}
+  .kcvf .k-sidebar{order:-1;display:none}
+  .kcvf .k-sidebar.is-open{display:block}
   .kcvf thead{display:none}
   .kcvf table,.kcvf tbody,.kcvf tr,.kcvf td{display:block;width:100%}
   .kcvf tbody tr{border-top:1px solid var(--divider);padding:8px 12px}

--- a/js/tracker.js
+++ b/js/tracker.js
@@ -1,0 +1,100 @@
+(function(){
+  const state = {page:1, search:'', client:'', process:'', stage:''};
+  const tbody = document.getElementById('k-rows');
+  const pager = document.getElementById('k-page');
+
+  function statusStep(status){
+    if(!status) return 1;
+    status = status.toLowerCase();
+    if(status.includes('reject')) return 'rejected';
+    const step1 = ['identificado','contactado','lista larga','long list'];
+    const step2 = ['entrevista','shortlist'];
+    const step3 = ['oferta','placement','colocado'];
+    if(step3.some(s=>status.includes(s))) return 3;
+    if(step2.some(s=>status.includes(s))) return 2;
+    return 1;
+  }
+
+  function renderRows(items){
+    tbody.innerHTML='';
+    items.forEach(item=>{
+      const tr=document.createElement('tr');
+      const cb=document.createElement('td');
+      cb.className='checkbox';
+      cb.innerHTML='<input type="checkbox" class="k-rowcheck" value="'+item.id+'">';
+      const name=document.createElement('td');
+      name.innerHTML='<a href="#" class="k-candidate" data-id="'+item.id+'">'+item.meta.first_name+' '+item.meta.last_name+'</a>';
+      const intNo=document.createElement('td');
+      intNo.textContent=item.meta.int_no||'';
+      const stage=document.createElement('td');
+      const step=statusStep(item.status);
+      if(step==='rejected'){
+        stage.innerHTML='<span class="chip chip--rejected">Rechazado</span>';
+      }else{
+        stage.innerHTML='<span class="k-progress">'
+          +'<span class="k-step'+(step>=1?' is-done':'')+'"></span>'
+          +'<span class="k-step'+(step>=2?' is-done':'')+(step===2?' is-current':'')+'"></span>'
+          +'<span class="k-step'+(step>=3?' is-done':'')+(step===3?' is-current':'')+'"></span>'
+          +'</span>';
+      }
+      const actions=document.createElement('td');
+      actions.innerHTML='<button class="btn btn--ghost">Ver</button>';
+      tr.append(cb,name,intNo,stage,actions);
+      tbody.appendChild(tr);
+    });
+  }
+
+  function fetchData(){
+    const params=new URLSearchParams({
+      action:'kvt_get_candidates',
+      _ajax_nonce:KVT.nonce,
+      search:state.search,
+      client:state.client,
+      process:state.process,
+      stage:state.stage,
+      page:state.page
+    });
+    fetch(KVT.ajaxurl,{method:'POST',body:params}).then(r=>r.json()).then(res=>{
+      if(res.success){
+        renderRows(res.data.items);
+        pager.textContent=state.page+' / '+res.data.pages;
+      }
+    });
+  }
+
+  let to;
+  const searchInput=document.getElementById('k-search');
+  if(searchInput){
+    searchInput.addEventListener('input',e=>{
+      state.search=e.target.value;
+      clearTimeout(to);
+      to=setTimeout(()=>{state.page=1;fetchData();},300);
+    });
+  }
+
+  document.getElementById('k-prev').addEventListener('click',()=>{
+    if(state.page>1){state.page--;fetchData();}
+  });
+  document.getElementById('k-next').addEventListener('click',()=>{
+    state.page++;fetchData();
+  });
+
+  ['k-filter-client','k-filter-process','k-filter-stage'].forEach(id=>{
+    const el=document.getElementById(id);
+    if(el){
+      el.addEventListener('change',e=>{
+        state[id.replace('k-filter-','')] = e.target.value;
+        state.page=1;fetchData();
+      });
+    }
+  });
+
+  const toggle=document.getElementById('k-toggle-activity');
+  if(toggle){
+    toggle.addEventListener('click',()=>{
+      document.getElementById('k-sidebar').classList.toggle('is-open');
+    });
+  }
+
+  fetchData();
+})();

--- a/page-tracker.php
+++ b/page-tracker.php
@@ -1,0 +1,74 @@
+<?php
+if (!defined('ABSPATH')) exit;
+?>
+<div class="wrap kcvf">
+  <header class="k-header">
+    <div>
+      <h1 class="k-title"><?php esc_html_e('Seguimiento de Candidatos', 'kovacic'); ?></h1>
+      <span class="k-pill k-pill--blue"><?php esc_html_e('Etapa actual', 'kovacic'); ?></span>
+    </div>
+    <div class="k-badges">
+      <span class="k-pill"><?php esc_html_e('Lista larga', 'kovacic'); ?>: <span id="stat-long">0</span></span>
+      <span class="k-pill k-pill--green"><?php esc_html_e('Entrevistas', 'kovacic'); ?>: <span id="stat-interviews">0</span></span>
+      <span class="k-pill k-pill--blue"><?php esc_html_e('Ofertas', 'kovacic'); ?>: <span id="stat-offers">0</span></span>
+    </div>
+  </header>
+  <nav class="k-tabs" role="tablist">
+    <div class="k-tab" aria-selected="false"><?php esc_html_e('Detalles', 'kovacic'); ?></div>
+    <div class="k-tab" aria-selected="true"><?php esc_html_e('ATS', 'kovacic'); ?></div>
+    <div class="k-tab" aria-selected="false"><?php esc_html_e('Agenda de entrevistas', 'kovacic'); ?></div>
+    <div class="k-tab" aria-selected="false"><?php esc_html_e('Contrataciones', 'kovacic'); ?></div>
+    <div class="k-tab" aria-selected="false"><?php esc_html_e('Notas', 'kovacic'); ?></div>
+    <div class="k-tab" aria-selected="false"><?php esc_html_e('Candidaturas', 'kovacic'); ?></div>
+  </nav>
+  <section class="k-tabpanel">
+    <div class="k-filters">
+      <input type="search" id="k-search" class="k-input" placeholder="<?php esc_attr_e('Buscar', 'kovacic'); ?>">
+      <select id="k-filter-client" class="k-select"><option value=""><?php esc_html_e('Cliente', 'kovacic'); ?></option></select>
+      <select id="k-filter-process" class="k-select"><option value=""><?php esc_html_e('Proceso', 'kovacic'); ?></option></select>
+      <select id="k-filter-stage" class="k-select"><option value=""><?php esc_html_e('Etapa', 'kovacic'); ?></option></select>
+      <button class="btn btn--ghost" id="k-add-filter"><?php esc_html_e('Crear nuevo filtro', 'kovacic'); ?></button>
+      <button class="btn k-activity-toggle" id="k-toggle-activity"><?php esc_html_e('Actividad', 'kovacic'); ?></button>
+    </div>
+    <div class="k-bulkbar" id="k-bulkbar" hidden>
+      <div class="k-bulkactions">
+        <button class="btn"><?php esc_html_e('Mover etapa', 'kovacic'); ?></button>
+        <button class="btn"><?php esc_html_e('Enviar correo', 'kovacic'); ?></button>
+        <button class="btn"><?php esc_html_e('Exportar CSV', 'kovacic'); ?></button>
+        <button class="btn"><?php esc_html_e('Eliminar', 'kovacic'); ?></button>
+      </div>
+    </div>
+    <div class="k-layout">
+      <div>
+        <div class="k-tablewrap">
+          <table class="k-table" aria-describedby="k-page">
+            <thead>
+              <tr>
+                <th class="checkbox"><input type="checkbox" id="k-select-all" aria-label="<?php esc_attr_e('Seleccionar todos', 'kovacic'); ?>"></th>
+                <th class="sortable" data-sort="candidate" aria-sort="none"><?php esc_html_e('Candidato', 'kovacic'); ?></th>
+                <th class="sortable" data-sort="int_no" aria-sort="none"><?php esc_html_e('No. Ent.', 'kovacic'); ?></th>
+                <th><?php esc_html_e('Etapa actual', 'kovacic'); ?></th>
+                <th><?php esc_html_e('Acciones', 'kovacic'); ?></th>
+              </tr>
+            </thead>
+            <tbody id="k-rows"></tbody>
+          </table>
+        </div>
+        <div class="k-pager">
+          <button class="btn" id="k-prev"><?php esc_html_e('Anterior', 'kovacic'); ?></button>
+          <span id="k-page"></span>
+          <button class="btn" id="k-next"><?php esc_html_e('Siguiente', 'kovacic'); ?></button>
+        </div>
+      </div>
+      <aside class="k-sidebar" id="k-sidebar">
+        <div class="k-sidehead"><?php esc_html_e('Actividad', 'kovacic'); ?></div>
+        <div class="k-activity" id="k-activity-feed"></div>
+        <div class="k-sideactions">
+          <button class="btn btn--primary" id="k-log-call"><?php esc_html_e('Registrar llamada', 'kovacic'); ?></button>
+          <button class="btn" id="k-new-event"><?php esc_html_e('Nuevo evento', 'kovacic'); ?></button>
+          <button class="btn" id="k-new-task"><?php esc_html_e('Nueva tarea', 'kovacic'); ?></button>
+        </div>
+      </aside>
+    </div>
+  </section>
+</div>


### PR DESCRIPTION
## Summary
- add Salesforce-like ATS tracker admin page in Spanish with tabs, filters, and activity sidebar
- load tracker assets only on Kovacic > ATS page and localize AJAX endpoints
- document AJAX endpoints and hooks

## Testing
- `php -l plugin_pipeline.php`
- `php -l page-tracker.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5c80116b4832a90aeda3f92524c8a