### PR TITLE
Expose role and company loader from board nav

### DIFF
--- a/plugin_pipeline.php
+++ b/plugin_pipeline.php
@@ -3046,15 +3046,21 @@ function kvtInit(){
   boardExportXls && boardExportXls.addEventListener('click', ()=>{ boardExportFormat.value='xls'; boardExportAllForm && boardExportAllForm.submit(); });
   const triggerLoadRoles = btn => {
     if(btn) btn.disabled = true;
-    ajaxForm({action:'kvt_generate_roles', _ajax_nonce:KVT_NONCE}).then(res=>{
-      if(btn) btn.disabled = false;
-      if(res && res.success){
-        refresh();
-        listProfiles(currentPage, boardCtx);
-      } else {
-        alert('No se pudo cargar roles y empresas');
-      }
-    });
+    ajaxForm({action:'kvt_generate_roles', _ajax_nonce:KVT_NONCE})
+      .then(res => {
+        if(btn) btn.disabled = false;
+        if(res && res.success){
+          refresh();
+          listProfiles(currentPage, boardCtx);
+        } else {
+          const msg = res && res.data && res.data.msg ? res.data.msg : 'No se pudo cargar roles y empresas';
+          alert(msg);
+        }
+      })
+      .catch(() => {
+        if(btn) btn.disabled = false;
+        alert('Error de red al cargar roles y empresas');
+      });
   };
   boardLoadRoles && boardLoadRoles.addEventListener('click', ()=>triggerLoadRoles(boardLoadRoles));
   navLoadRoles && navLoadRoles.addEventListener('click', e=>{ e.preventDefault(); triggerLoadRoles(navLoadRoles); });


### PR DESCRIPTION
## Summary
- add a nav link to load roles and companies
- clarify role loader button text
- support nav link in JS

## Testing
- `php -l plugin_pipeline.php`


------
https://chatgpt.com/codex/tasks/task_e_68b70c0225bc832aa1905f61cb4d45c5