### PR TITLE
Embed bulk mailer into pipeline frontend

### DIFF
--- a/bulkemail
+++ b/bulkemail
@@ -1342,4 +1342,7 @@ function ktDownloadEMLZip(){
     }
 }
 
-new KT_AIBulkMailer_ES();
+// Expose instance globally for reuse outside the admin screen.
+// This keeps backward compatibility while allowing other plugins
+// (e.g. the pipeline frontend) to render the bulk mailer UI.
+$GLOBALS['kt_abm'] = new KT_AIBulkMailer_ES();


### PR DESCRIPTION
## Summary
- load Bulk Email plugin from Pipeline
- render bulk email interface inside pipeline shortcode output
- enqueue Bulk Email assets on frontend

## Testing
- `php -l bulkemail`
- `php -l plugin_pipeline.php`


------
https://chatgpt.com/codex/tasks/task_e_68babac8e070832abd3755f3a770bb9a