### PR TITLE
Increase OpenAI request timeout

### DIFF
--- a/plugin_pipeline.php
+++ b/plugin_pipeline.php
@@ -5209,6 +5209,7 @@ JS;
                     ['role' => 'user', 'content' => $prompt],
                 ],
             ]),
+            'timeout' => 60,
         ]);
         if (is_wp_error($resp)) {
             $err = $resp->get_error_message();


### PR DESCRIPTION
## Summary
- add explicit 60 second timeout to MIT suggestions OpenAI call to avoid premature cURL failures

## Testing
- `php -l plugin_pipeline.php`
- `curl --max-time 5 http://127.0.0.1:8000/slow.php` *(fails: Operation timed out)*
- `curl --max-time 60 http://127.0.0.1:8000/slow.php`

------
https://chatgpt.com/codex/tasks/task_e_68bb45ef3118832aa28767edd95d0d9e