### PR TITLE
Move activity panel below candidate table

### DIFF
--- a/css/tracker.css
+++ b/css/tracker.css
@@ -110,7 +110,7 @@
 .kcvf .btn:focus{outline:2px solid rgba(1,118,211,.35);outline-offset:2px}
 
 /* Sidebar */
-.kcvf .k-layout{display:grid;grid-template-columns:1fr 300px;gap:calc(var(--gap)*2)}
+.kcvf .k-layout{display:grid;grid-template-columns:1fr;gap:calc(var(--gap)*2)}
 .kcvf .k-sidebar{
   background:var(--surface);border:1px solid var(--divider);border-radius:var(--radius);box-shadow:var(--shadow);
   padding:calc(var(--gap)*2)
@@ -133,7 +133,7 @@
 /* Responsive */
 @media (max-width: 960px){
   .kcvf .k-layout{grid-template-columns:1fr}
-  .kcvf .k-sidebar{order:-1}
+  .kcvf .k-sidebar{order:0}
   .kcvf thead{display:none}
   .kcvf table,.kcvf tbody,.kcvf tr,.kcvf td{display:block;width:100%}
   .kcvf tbody tr{border-top:1px solid var(--divider);padding:8px 12px}


### PR DESCRIPTION
## Summary
- stack candidate list and activity sidebar vertically by default
- ensure sidebar order stays below table on narrow screens

## Testing
- `php -l plugin_pipeline.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcabf20e50832abf3f5fe7e8e6f458