### PR TITLE
Cache MIT context and invalidate when data changes

### DIFF
--- a/DEVELOPER_NOTES.md
+++ b/DEVELOPER_NOTES.md
@@ -1,0 +1,15 @@
+# Developer Notes
+
+## MIT Context Caching
+
+The `mit_gather_context()` function assembles data about candidates, clients, and processes for MIT reports. To avoid rebuilding this context on every request, the plugin now caches the generated summary and news using a WordPress transient.
+
+- **Key**: `kvt_mit_ctx_<hash>` where `<hash>` is `md5( get_site_url() )`.
+- **TTL**: 5 minutes.
+
+The cache is automatically cleared whenever relevant data changes:
+
+- Saving or deleting a `kvt_candidate` post.
+- Creating, editing, or deleting `kvt_client` or `kvt_process` terms.
+
+This ensures context is rebuilt when needed while reducing redundant computation.


### PR DESCRIPTION
## Summary
- cache MIT context for 5 minutes using transients keyed to the site
- clear cached context when candidates, clients or processes change
- document MIT context caching for maintainers

## Testing
- `php -l plugin_pipeline.php`


------
https://chatgpt.com/codex/tasks/task_e_68be10245b0c832aa5e211f75de183d9