### PR TITLE
Split followups into overdue and upcoming

### DIFF
--- a/plugin_pipeline.php
+++ b/plugin_pipeline.php
@@ -7096,7 +7096,8 @@ JS;
 
         $notes      = [];
         $cand_lines = [];
-        $followups  = [];
+        $overdue    = [];
+        $upcoming   = [];
         $history    = [];
         foreach ($cands as $c) {
             $country = get_post_meta($c->ID, 'kvt_country', true);
@@ -7145,7 +7146,11 @@ JS;
                     $na_note = get_post_meta($c->ID, 'kvt_next_action_note', true);
                     $fline = $c->post_title . ' - ' . $next;
                     if ($na_note) $fline .= ': ' . $na_note;
-                    $followups[] = $fline;
+                    if ($ts < current_time('timestamp')) {
+                        $overdue[] = $fline;
+                    } else {
+                        $upcoming[] = $fline;
+                    }
                 }
             }
             if (is_array($log)) {
@@ -7243,8 +7248,11 @@ JS;
         $summary  = 'Candidatos: ' . implode('; ', $cand_lines) . '.';
         $summary .= ' Clientes: ' . implode('; ', $client_lines) . '.';
         $summary .= ' Procesos: ' . implode('; ', $process_lines) . '.';
-        if ($followups) {
-            $summary .= ' Seguimientos pendientes: ' . implode('; ', $followups) . '.';
+        if ($overdue) {
+            $summary .= ' Seguimientos vencidos: ' . implode('; ', $overdue) . '.';
+        }
+        if ($upcoming) {
+            $summary .= ' Seguimientos próximos: ' . implode('; ', $upcoming) . '.';
         }
         if ($notes) {
             $summary .= ' Notas: ' . implode(' | ', $notes) . '.';


### PR DESCRIPTION
## Summary
- Separate followup reminders into overdue and upcoming arrays
- Add new summary sections for "Seguimientos vencidos" and "Seguimientos próximos"

## Testing
- `php -l plugin_pipeline.php`


------
https://chatgpt.com/codex/tasks/task_e_68be17696624832aaf353cf6a1907a90