### PR TITLE
Auto-fill candidate profile from CV and show sector

### DIFF
--- a/plugin_cv_feedback
+++ b/plugin_cv_feedback
@@ -660,6 +660,8 @@ Por favor, sube tu CV en DOCX o en PDF con texto seleccionable (OCR). También p
                 if ($file_text) {
                     update_post_meta($candidate_id, 'kvt_cv_text', $file_text);
                 }
+                // Completar perfil con datos del CV
+                do_action('kvt_update_profile_from_cv', $candidate_id);
             }
         }
 


### PR DESCRIPTION
## Summary
- Populate candidate profiles from CV data via new `kvt_update_profile_from_cv` hook
- Trigger automatic profile completion when CVs arrive through CV feedback plugin
- Expose candidate sector field in UI and default columns

## Testing
- `php -l plugin_pipeline.php`
- `php -l plugin_cv_feedback`


------
https://chatgpt.com/codex/tasks/task_e_68c02641c338832abc17a1c967872343